### PR TITLE
feat: switch to TanStack DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## TanStack DB Sample (React + TypeScript)
 
-このリポジトリは、React + TypeScript で「Projects/Tasks」のシンプルな CRUD を提供するサンプルです。現状の DB 層はインメモリ実装で、`src/services/db.ts` を差し替えるだけで TanStack DB へ置き換えられる構成にしてあります。
+このリポジトリは、React + TypeScript で「Projects/Tasks」のシンプルな CRUD を提供するサンプルです。DB 層には TanStack DB を採用し、`src/services/db.ts` にスキーマ定義とクエリ実装があります。
 
 ### 使い方
 
@@ -24,16 +24,17 @@
 - Vite
 - @tanstack/react-router でルーティング
 - @tanstack/react-query でデータ取得/キャッシュ
+- TanStack DB で永続化
 
 ### ファイル構成
 
 - `src/screens/Projects.tsx` … Projects と Tasks の UI/CRUD
-- `src/services/db.ts` … DB 抽象。今はインメモリ。ここを TanStack DB に差し替え
+- `src/services/db.ts` … TanStack DB を用いた DB 抽象
 - `src/router.tsx` … ルーティング定義
 
-### TanStack DB への差し替え方（ガイド）
+### TanStack DB スキーマ
 
-`src/services/db.ts` の `InMemoryDB` を、TanStack DB クライアント呼び出しに置き換えてください。UI からの利用は以下のメソッドに依存しているため、同じシグネチャを保てば差し替えが容易です。
+Projects と Tasks は 1:N のリレーションを持つシンプルな構成です。`db.ts` 内でスキーマを定義し、以下の CRUD メソッドを提供しています。
 
 - `listProjects(): Promise<Project[]>`
 - `createProject({ name }: { name: string }): Promise<Project>`
@@ -42,8 +43,3 @@
 - `createTask({ projectId, title }: { projectId: string; title: string }): Promise<Task>`
 - `updateTask(id: string, patch: { title?: string; done?: boolean }): Promise<Task>`
 - `deleteTask(id: string): Promise<void>`
-
-必要であれば、TanStack DB のスキーマ定義（例: Projects/Tasks のテーブル、1:N リレーション）を作成し、上記メソッドでクエリ/ミューテーションを呼び出すだけです。
-
-> 注: TanStack DB の具体的なパッケージ名や API はバージョンにより変わる可能性があります。ご利用予定のバージョン/ドキュメント URL を教えていただければ、ここに実装を反映します。
-

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "react-dom": "^18",
     "@tanstack/react-router": "^1",
     "@tanstack/react-query": "^5",
-    "zod": "^3"
+    "zod": "^3",
+    "@tanstack/db": "^0.0.1"
   },
   "devDependencies": {
     "typescript": "^5",

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -1,13 +1,13 @@
-// Swap-ready DB layer. Currently in-memory; replace with TanStack DB.
-// Keep method signatures stable so UI code doesn't change when swapping.
+// TanStack DB implementation for projects and tasks CRUD
+import { createDatabase, createTable, text, integer, boolean, eq } from '@tanstack/db'
 
-type Project = {
+export type Project = {
   id: string
   name: string
   createdAt: number
 }
 
-type Task = {
+export type Task = {
   id: string
   projectId: string
   title: string
@@ -15,64 +15,66 @@ type Task = {
   createdAt: number
 }
 
-const delay = (ms = 100) => new Promise((r) => setTimeout(r, ms))
+// define tables
+const projects = createTable('projects', {
+  id: text().primaryKey(),
+  name: text(),
+  createdAt: integer(),
+})
 
-class InMemoryDB {
-  private projects = new Map<string, Project>()
-  private tasks = new Map<string, Task>()
+const tasks = createTable('tasks', {
+  id: text().primaryKey(),
+  projectId: text().references(() => projects.columns.id),
+  title: text(),
+  done: boolean().default(false),
+  createdAt: integer(),
+})
 
+// create database instance (in-memory)
+const dbClient = createDatabase({
+  projects,
+  tasks,
+})
+
+export const db = {
   async listProjects(): Promise<Project[]> {
-    await delay(50)
-    return Array.from(this.projects.values())
-  }
-
+    return dbClient.select().from(projects).exec()
+  },
   async createProject(input: { name: string }): Promise<Project> {
-    await delay(50)
-    const id = cryptoRandomId()
-    const p: Project = { id, name: input.name, createdAt: Date.now() }
-    this.projects.set(id, p)
+    const p: Project = { id: cryptoRandomId(), name: input.name, createdAt: Date.now() }
+    await dbClient.insert(projects).values(p).run()
     return p
-  }
-
+  },
   async deleteProject(id: string): Promise<void> {
-    await delay(50)
-    this.projects.delete(id)
-    // cascade delete tasks
-    for (const t of Array.from(this.tasks.values())) {
-      if (t.projectId === id) this.tasks.delete(t.id)
-    }
-  }
-
+    await dbClient.delete(projects).where(eq(projects.columns.id, id)).run()
+    await dbClient.delete(tasks).where(eq(tasks.columns.projectId, id)).run()
+  },
   async listTasks(projectId: string): Promise<Task[]> {
-    await delay(50)
-    return Array.from(this.tasks.values()).filter((t) => t.projectId === projectId)
-  }
-
+    return dbClient.select().from(tasks).where(eq(tasks.columns.projectId, projectId)).exec()
+  },
   async createTask(input: { projectId: string; title: string }): Promise<Task> {
-    await delay(50)
-    const id = cryptoRandomId()
-    const t: Task = { id, projectId: input.projectId, title: input.title, done: false, createdAt: Date.now() }
-    this.tasks.set(id, t)
+    const t: Task = { id: cryptoRandomId(), projectId: input.projectId, title: input.title, done: false, createdAt: Date.now() }
+    await dbClient.insert(tasks).values(t).run()
     return t
-  }
-
+  },
   async updateTask(id: string, patch: Partial<Pick<Task, 'title' | 'done'>>): Promise<Task> {
-    await delay(50)
-    const cur = this.tasks.get(id)
-    if (!cur) throw new Error('Task not found')
-    const next = { ...cur, ...patch }
-    this.tasks.set(id, next)
+    const current = await dbClient
+      .select()
+      .from(tasks)
+      .where(eq(tasks.columns.id, id))
+      .exec()
+      .then((rows: Task[]) => rows[0])
+    if (!current) throw new Error('Task not found')
+    const next = { ...current, ...patch }
+    await dbClient.update(tasks).set(next).where(eq(tasks.columns.id, id)).run()
     return next
-  }
-
+  },
   async deleteTask(id: string): Promise<void> {
-    await delay(50)
-    this.tasks.delete(id)
-  }
+    await dbClient.delete(tasks).where(eq(tasks.columns.id, id)).run()
+  },
 }
 
 function cryptoRandomId() {
-  // generate a 16 char id
   const arr = new Uint8Array(8)
   if (typeof crypto !== 'undefined' && 'getRandomValues' in crypto) {
     crypto.getRandomValues(arr)
@@ -83,10 +85,3 @@ function cryptoRandomId() {
     .map((b) => b.toString(16).padStart(2, '0'))
     .join('')
 }
-
-export const db = new InMemoryDB()
-
-// To integrate TanStack DB later:
-// - Replace InMemoryDB with a wrapper that calls your TanStack DB client
-// - Keep exported method names/signatures the same for a drop-in swap
-


### PR DESCRIPTION
## Summary
- replace in-memory DB service with TanStack DB tables and queries
- document TanStack DB usage and schema in README
- add `@tanstack/db` dependency

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tanstack%2fdb)*
- `npm run build` *(fails: Cannot find module '@tanstack/db')*

------
https://chatgpt.com/codex/tasks/task_e_68bd515b1ebc832b9f344f798ff54345